### PR TITLE
Add support for older v. of StashBuildTrigger

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -2,13 +2,14 @@
     name: 'stash-pr-test'
 
     triggers:
+      # example for plugin ver. >= 1.5.0
       - stash:
           spec: '* * * * *'
           cron: '* * * * *'
           stash_host: 'http://git.example.org/'
           project_code: '~username'
           repository_name: 'my_repository'
-          credentials_id: 'StashGitCredentials'
+          credentials_id: 'StashGitCredentials'  # note this
           ci_skip_phrases: 'NO TEST'
           ci_build_phrases: 'test this please'
           target_branches_to_build: ''
@@ -20,3 +21,24 @@
           only_build_on_comment: 'false'
           delete_previous_build_finish_comments: 'false'
           cancel_outdated_jobs_enabled: 'true'
+      
+      # example for plugin ver. < 1.5.0
+      - stash:
+          spec: '* * * * *'
+          cron: '* * * * *'
+          stash_host: 'http://git.example.org/'
+          project_code: '~username'
+          repository_name: 'my_repository'
+          username: "Stash User"  # note this
+          password: "qwe123"  # note this
+          ci_skip_phrases: 'NO TEST'
+          ci_build_phrases: 'test this please'
+          target_branches_to_build: ''
+          ignore_ssl: 'true'
+          check_destination_commit: 'false'
+          check_mergeable: 'false'
+          merge_on_success: 'false'
+          check_not_conflicted: 'false'
+          only_build_on_comment: 'false'
+          delete_previous_build_finish_comments: 'false'
+          cancel_outdated_jobs_enabled: 'true'      

--- a/jenkins_jobs_stash_pr/stash.py
+++ b/jenkins_jobs_stash_pr/stash.py
@@ -16,6 +16,8 @@ OPTIONAL = [
     ('spec', 'spec', ''),
     ('cron', 'cron', ''),
     ('credentials_id','credentialsId', ''),
+    ('username','username', ''),  # support for ver < 1.5.0
+    ('password','password', ''),  # support for ver < 1.5.0
     ('ci_skip_phrases', 'ciSkipPhrases', 'NO TEST'),
     ('ci_build_phrases', 'ciBuildPhrases', 'test this please'),
     ('target_branches_to_build', 'targetBranchesToBuild',''),


### PR DESCRIPTION
This patch adds optional fields for username and password
which were removed in StashBuildTrigger-1.5.0.

Providing credentials in YAML is not secure but it could
be safier than plugin update.